### PR TITLE
Detect implicit TBB dependence of parallel STL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     set(CMAKE_REQUIRED_FLAGS "-std=c++17")
     check_cxx_symbol_exists(__PSTL_PAR_BACKEND_TBB "cstddef" STL_DEPENDS_ON_TBB)
     if(STL_DEPENDS_ON_TBB)
+        find_package(TBB REQUIRED)
         target_link_libraries(
             ${PROJECT_NAME} INTERFACE TBB::tbb)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,15 @@ if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 
     target_compile_options(${PROJECT_NAME} INTERFACE -fopenmp-simd)
     target_link_libraries(
-        ${PROJECT_NAME} INTERFACE ${CMAKE_DL_LIBS} Threads::Threads tbb)
+        ${PROJECT_NAME} INTERFACE ${CMAKE_DL_LIBS} Threads::Threads)
+
+    include(CheckCXXSymbolExists)
+    set(CMAKE_REQUIRED_FLAGS "-std=c++17")
+    check_cxx_symbol_exists(__PSTL_PAR_BACKEND_TBB "cstddef" STL_DEPENDS_ON_TBB)
+    if(STL_DEPENDS_ON_TBB)
+        target_link_libraries(
+            ${PROJECT_NAME} INTERFACE TBB::tbb)
+    endif()
 else ()
     target_compile_options(${PROJECT_NAME} INTERFACE /openmp:experimental)
 endif ()


### PR DESCRIPTION
This PR addresses #11.

It includes the lightest of STL headers in C++17 mode which immediately pulls in `bits/c++config.h` which in turn includes `pstl/pstl_config.h` which exposes the half-baked machinery of PSTL back-end detection and simply defaults to TBB.

![image](https://user-images.githubusercontent.com/9763499/104324703-10723c80-54e8-11eb-8f6b-e91fa61b50b4.png)

CMake script looks for the macro `__PSTL_PAR_BACKEND_TBB ` and if present searches for TBB and links to it. It is still not bullet-proof, but better than the current linkage to system TBB.

_(Note: does not support TBB versions prior to 2017 [as per the docs](https://github.com/oneapi-src/oneTBB/tree/2018_U6/cmake#binary-package-integration), but that shouldn't matter, as minimum requirements for PSTL is 2018.)_