### PR TITLE
shfl_up implementation

### DIFF
--- a/include/hip/hip_api.h
+++ b/include/hip/hip_api.h
@@ -138,9 +138,10 @@ template<
         (std::is_integral_v<T> || std::is_floating_point_v<T>) &&
         (sizeof(T) >= 4 && sizeof(T) <= 8)>* = nullptr>
 inline
-T __shfl_up(T, std::uint32_t, std::int32_t = warpSize) noexcept
+T __shfl_up(
+    T var, std::uint32_t delta, std::int32_t width = warpSize) noexcept
 {
-    static_assert(sizeof(T) == 0, "Not yet implemented.");
+    return hip::detail::shuffle_up(var, delta, width);
 }
 
 template<

--- a/src/include/hip/detail/intrinsics.hpp
+++ b/src/include/hip/detail/intrinsics.hpp
@@ -231,6 +231,24 @@ namespace hip
                 (std::is_integral_v<T> || std::is_floating_point_v<T>) &&
                 (sizeof(T) >= 4 && sizeof(T) <= 8)>* = nullptr>
         inline
+        T shuffle_up(T x, std::int32_t dx, std::int32_t w) noexcept
+        {   // TODO: incorrect with large negative offsets, revisit.
+            const auto tidx{id(Fiber::this_fiber())};
+            Tile::scratchpad<T>()[tidx] = x;
+
+            Tile::this_tile().barrier();
+
+            const auto sidx{(tidx / w * w) + (tidx % w) - dx};
+
+            return (sidx < 0u || sidx >= (std::uint32_t)w) ? x : Tile::scratchpad<T>()[sidx];
+        }
+
+        template<
+            typename T,
+            std::enable_if_t<
+                (std::is_integral_v<T> || std::is_floating_point_v<T>) &&
+                (sizeof(T) >= 4 && sizeof(T) <= 8)>* = nullptr>
+        inline
         T shuffle_xor(T x, std::int32_t src, std::int32_t w) noexcept
         {   // TODO: probably incorrect, revisit.
             const auto tidx{id(Fiber::this_fiber())};


### PR DESCRIPTION
Given how little the difference is between shfl_up and shfl_down, I went ahead and implemented a rudimentary version (borrowed from shfl_down, aside from the delta op).

The absence of this API implementation is blocking rocPRIM from supporting HIP-CPU port.