### PR TITLE
Fix outdated examples

### DIFF
--- a/examples/hip_event/hipEvent.cpp
+++ b/examples/hip_event/hipEvent.cpp
@@ -42,7 +42,7 @@ int main() {
     float* gpuTransposeMatrix;
 
     hipDeviceProp_t devProp;
-    hipGetDeviceProperties(&devProp, INT_MAX);
+    hipGetDeviceProperties(&devProp, 0);
 
     std::cout << "Device name " << devProp.name << std::endl;
 

--- a/examples/hip_info/hipInfo.cpp
+++ b/examples/hip_info/hipInfo.cpp
@@ -187,7 +187,7 @@ int main(int argc, char* argv[]) {
 
     for (int i = 0; i < deviceCnt; i++) {
         hipSetDevice(i);
-        printDeviceProp(INT_MAX);
+        printDeviceProp(i);
     }
 
     std::cout << std::endl;

--- a/examples/matrix_transpose/MatrixTranspose.cpp
+++ b/examples/matrix_transpose/MatrixTranspose.cpp
@@ -43,7 +43,7 @@ int main() {
     float* gpuTransposeMatrix;
 
     hipDeviceProp_t devProp;
-    hipGetDeviceProperties(&devProp, INT_MAX);
+    hipGetDeviceProperties(&devProp, 0);
 
     std::cout << "Device name " << devProp.name << std::endl;
 

--- a/examples/occupancy/occupancy.cpp
+++ b/examples/occupancy/occupancy.cpp
@@ -32,7 +32,7 @@ void multiplyCPU(float* C, float* A, float* B, int N) {
 
 void launchKernel(float* C, float* A, float* B, bool manual) {
      hipDeviceProp_t devProp;
-     HIP_CHECK(hipGetDeviceProperties(&devProp, INT_MAX));
+     HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
 
      hipEvent_t start, stop;
      HIP_CHECK(hipEventCreate(&start));

--- a/examples/square/square.cpp
+++ b/examples/square/square.cpp
@@ -42,7 +42,7 @@ int main()
         float *A_h, *C_h;
         size_t N = 1000000;
         size_t Nbytes = N * sizeof(float);
-        static int device = INT_MAX;
+        static int device = 0;
         CHECK(hipSetDevice(device));
         hipDeviceProp_t props;
         CHECK(hipGetDeviceProperties(&props, device /*deviceID*/));


### PR DESCRIPTION
These examples were failing, and they were the only ones to use `INT_MAX`. All the tests and other examples worked fine, so I assume these had just not been updated when some implementation detail of HIP-CPU changed.