### PR TITLE
Include cstring standard library in api.h

### DIFF
--- a/src/include/hip/detail/api.hpp
+++ b/src/include/hip/detail/api.hpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <utility>
+#include <cstring>
 
 namespace hip
 {


### PR DESCRIPTION
This fixes a bug of "no member named 'memcpy' in namespace 'std'" for the lines containing "std::memcpy" (and similarly with "std::memset")